### PR TITLE
Missing build tasks added

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -120,7 +120,7 @@ steps:
     chartType: filepath
     chartPath: helm
     releaseName: $(imageName)-$(containerTag)
-    arguments: --set image=$(azureContainerRegistryFull)/$(imageName):$(containerTag) --set container.redeployOnChange=$(Build.BuildId) --set container.imagePullPolicy=Always
+    arguments: --set image=$(azureContainerRegistryFull)/$(imageName):$(containerTag) --set container.redeployOnChange=$(Build.BuildId) --set container.imagePullPolicy=Always --atomic
     install: true
     recreate: true
     waitForExecution: true

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -122,6 +122,7 @@ steps:
     releaseName: $(imageName)-$(containerTag)
     arguments: --set image=$(azureContainerRegistryFull)/$(imageName):$(containerTag) --set container.redeployOnChange=$(Build.BuildId) --set container.imagePullPolicy=Always
     install: true
+    recreate: true
     waitForExecution: true
   displayName: Helm deploy
   # delete helm chart of closed PR
@@ -175,3 +176,25 @@ steps:
 - script: |
     echo "Build available for review in namespace $(imageName)-$(containerTag)"
   displayName: display namespace of deployed build
+# install helm on build agent
+- task: HelmInstaller@0
+  displayName: 'Install Helm 2.9.1'
+  inputs:
+    helmVersion: 2.9.1
+  # package helm chart for release
+- task: HelmDeploy@0
+  displayName: 'helm package'
+  inputs:
+    command: package
+    chartPath: ./helm
+    save: false
+  # copy yaml values for release  
+- task: CopyFiles@2
+  displayName: 'Copy values files'
+  inputs:
+    SourceFolder: helm
+    Contents: '*-values.yaml'
+    TargetFolder: '$(Build.ArtifactStagingDirectory)'
+  # publish artifact for release
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Artifacts: drop'

--- a/helm/production-values.yaml
+++ b/helm/production-values.yaml
@@ -1,4 +1,4 @@
 environment: production
-image: minesupport.azurecr.io/mine-support-api-gateway
+image: jwminesupport.azurecr.io/mine-support-api-gateway
 container:
   imagePullPolicy: Always

--- a/helm/production2-values.yaml
+++ b/helm/production2-values.yaml
@@ -1,4 +1,0 @@
-environment: production
-image: jwminesupport.azurecr.io/mine-support-api-gateway
-container:
-  imagePullPolicy: Always


### PR DESCRIPTION
Currently there are no build tasks to package the helm chart for the release pipeline.  These changes correct that.