### PR TITLE
Update claim service URL

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -17,7 +17,7 @@ container:
   readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
   userServiceUrl: http://mine-support-user-service.default
-  claimServiceUrl: http://mine-support-claim-service.default:3003
+  claimServiceUrl: http://mine-support-claim-service.default
   restartPolicy: Always
 replicaCount: 1
 minReadySeconds: 5


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FPD-296

The clain service has changed to use port 80. This PR changes the port
in the URL from 3003 to 80.