### PR TITLE
Allow Optional Registry Credentials

### DIFF
--- a/helm/production-values.yaml
+++ b/helm/production-values.yaml
@@ -1,4 +1,4 @@
 environment: production
-image: jwminesupport.azurecr.io/mine-support-api-gateway
+image: jwminesupport.azurecr.io/mine-support-api-gateway:master
 container:
   imagePullPolicy: Always

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -13,8 +13,11 @@ spec:
       annotations:
         redeployOnChange: "{{ .Values.container.redeployOnChange }}"
     spec:
-
       restartPolicy: {{ .Values.container.restartPolicy }}
+      {{- if .Values.imagePullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.imagePullSecret }}
+      {{- end }}
       containers:
         - name: {{ .Values.name }}
           image: {{ .Values.image }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -2,6 +2,7 @@ environment: development
 name:  mine-support-api-gateway
 image:  mine-support-api-gateway
 restClientTimeoutMillis: 10000
+imagePullSecret:
 service:
   type: ClusterIP
   port: 80


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FPD-440

To deploy from a private registry into a Kubernetes cluster registry
credentials must be supplied. this PR adds configuration to the
deployment chart to allow authentication.