### PR TITLE
Revert default service URLs to default namespace

### DIFF
--- a/helm/ffc-demo-api-gateway/jenkins-aws.yaml
+++ b/helm/ffc-demo-api-gateway/jenkins-aws.yaml
@@ -3,3 +3,5 @@ name: ffc-demo-api-gateway
 imagePullSecret: myregistrykey
 container:
   imagePullPolicy: Always
+  claimServiceUrl: http://ffc-demo-claim-service.ffc-demo
+  userServiceUrl: http://ffc-demo-user-service.ffc-demo

--- a/helm/ffc-demo-api-gateway/values.yaml
+++ b/helm/ffc-demo-api-gateway/values.yaml
@@ -17,8 +17,8 @@ container:
   runAsUser: 1000
   readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
-  userServiceUrl: http://ffc-demo-user-service.ffc-demo
-  claimServiceUrl: http://ffc-demo-claim-service.ffc-demo
+  claimServiceUrl: http://ffc-demo-claim-service.default
+  userServiceUrl: http://ffc-demo-user-service.default
   restartPolicy: Always
 replicaCount: 1
 minReadySeconds: 5


### PR DESCRIPTION
The Azure deployments currently go into the `default` namespace so that
needs to be in the URLs set by default Helm deployments.