### PR TITLE
priorityClassName specified in the wrong place

### DIFF
--- a/helm/ffc-demo-api-gateway/templates/deployment.yaml
+++ b/helm/ffc-demo-api-gateway/templates/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: {{ quote .Values.namespace }}
   labels: {{ include "ffc-demo.labels" . | trimSuffix "\n" | indent 2 }}
 spec:
-  priorityClassName: {{ quote .Values.container.priorityClassName }}
   replicas: {{ .Values.replicaCount }}
   minReadySeconds: {{ .Values.minReadySeconds }}
   selector:
@@ -19,6 +18,7 @@ spec:
       annotations:
         redeployOnChange: {{ quote .Values.container.redeployOnChange }}
     spec:
+      priorityClassName: {{ quote .Values.container.priorityClassName }}
       restartPolicy: {{ quote .Values.container.restartPolicy }}
       {{- if .Values.imagePullSecret }}
       imagePullSecrets:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ffc-demo-api-gateway",
   "description": "Digital service demonstration application to claim public money in the event property subsides into mine shaft.",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "repository": {
     "type": "git",
     "url": "https://github.com/DEFRA/mine-support-api-gateway.git"


### PR DESCRIPTION
Helm 3 has highlighed an issue where priorityClassName is specified in
the spec of the deployment rather than the pod further down.